### PR TITLE
Latest NW Monitoring Enhancements

### DIFF
--- a/OnPageCode_timeout.js
+++ b/OnPageCode_timeout.js
@@ -1,289 +1,458 @@
-var PM_Network_POC = {
+(function () {
+  function getDeviceType () {
+    const userAgent = window.navigator.userAgent.toLowerCase();
+    const device = {};
 
-  // IMP: Which namespace to be used, can be identify using,
-  // 1. Go to publisher URL.
-  // 2. Open developer tool and select console tab
-  // 3. Execute below code in the console,
-  //    3.1 window.owpbjs
-  //    If it returns object with some properties, use owpbjs as prebidNamespace
-  //    else, try changing namespace with pbjs (code: window.pbjs)   
-  //    3.2 In case of IDHUB only, use code, window.ihowpbjs
-  // 4. Or connect to JS developer
-
-  'prebidNamespace': 'owpbjs',
-
-  'publisherId': 1234,
-
-  // N second after auction end, get the stats for given domains
-  'executionDelayInMs': 2000,
-
-  // run the Network analysis only for the mentioned percentage of traffic
-  'testGroupPercentage': 100,
-
-  'statHatParameters': [
-    {
-      key: "dns",
-      name: "DNS Lookup",
-      timeEndKey: "domainLookupEnd",
-      timeStartKey: "domainLookupStart"
-    },
-    {
-      key: "tcp",
-      name: "TCP Connection",
-      timeEndKey: "connectEnd",
-      timeStartKey: "connectStart"
-    },
-    {
-      key: "que_st",
-      name: "Queueing and stalled",
-      timeEndKey: "requestStart",
-      timeStartKey: "startTime"
-    },
-    {
-      key: "rs_wfs",
-      name: "Request Sent and Waiting For Server",
-      timeEndKey: "responseStart",
-      timeStartKey: "requestStart"
-    },
-    {
-      key: "cd",
-      name: "Content Download",
-      timeEndKey: "responseEnd",
-      timeStartKey: "responseStart"
-    },
-    {
-      key: "dur",
-      name: "Duration",
-      timeEndKey: "responseEnd",
-      timeStartKey: "startTime"
-    }
-  ],
-
-  // bidders to monitor, bidderName => domain to monitor
-  'bidders': [
-    {
-      key: "pm",
-      name: "PubMatic",
-      bidderCode: "pubmatic",
-      searchName: "hbopenbid.pubmatic.com",
-      //reqMethod: 'POST'
-    },
-    {
-      // NOTE: This Object will replace dyanmically depends on dynamic change in translator endpoint config
-      key: "pm",
-      name: "PubMatic",
-      bidderCode: "pubmatic",
-      searchName: "openbidtest-ams.pubmatic.com",
-      //reqMethod: 'GET'
-    },
-    {
-      key: "an",
-      name: "AppNexus",
-      bidderCode: "appnexus",
-      searchName: "ib.adnxs.com"
-    },
-    {
-      key: "tl",
-      name: "TripleLift",
-      bidderCode: "triplelift",
-      searchName: "tlx.3lift.com"
-    },
-    {
-      key: "rc",
-      name: "Rubicon",
-      bidderCode: "rubicon",
-      searchName: "fastlane.rubiconproject.com"
-    }
-  ],
-
-  // need to log domain in stats
-  'domain': (function () {
-    const replaceList = ['https://', 'http://'];
-    let hostName = window?.location?.hostname;
-    replaceList.forEach(replaceThis => {
-      hostName = hostName.replace(replaceThis, '');
-    });
-    return hostName;
-  })(),
-
-  'browserName': (function () {
-    let userAgent = navigator?.userAgent || "others";
-    if (userAgent.match(/firefox|fxios/i)) return "firefox";
-    if (userAgent.match(/chrome|chromium|crios/i)) return "chrome";
-    if (userAgent.match(/safari/i)) return "safari";
-    if (userAgent.match(/opr\//i)) return "opera";
-    if (userAgent.match(/edg/i)) return "edge";
-    return "others";
-  })(),
-
-  // to make sure that we do not read the stats for the same network call again
-  'lastExecutionMaxIndex': 0,
-
-  getTimeValue: function (endTime, startTime) {
-    if (isNaN(endTime) || isNaN(startTime)) return -1;
-    if (endTime === 0 || startTime === 0) return -1;
-    return endTime - startTime;
-  },
-
-  uploadTheNetworkLatencyData: function (jsonData) {
-    fetch("https://pm-network-latency-monitoring.harshad.workers.dev/", {
-      "headers": {
-        "content-type": "application/json"
-      },
-      "method": "POST",
-      "body": JSON.stringify(jsonData)
-    })
-      .then(res => { })
-      .then(response => { })
-      .catch(error => { });
-  },
-
-  getParameterByName: function (name, url) {
-    name = name.replace(/[\[\]]/g, '\\$&');
-    var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
-      results = regex.exec(url);
-    if (!results)
-      return null;
-    if (!results[2])
-      return '';
-    return decodeURIComponent(results[2].replace(/\+/g, ' '));
-  },
-
-  isBidTimeout: function (bidderRequest) {
-    return bidderRequest?.bids?.some(bid => bid.t === 1);
-  },
-
-  prepareNetworkLatencyData: function (perfResource, bidderRequest, latency) {
-    let output = {
-      domain: PM_Network_POC.domain,
-      publisherId: PM_Network_POC.publisherId,
-      browser: PM_Network_POC.browserName,
-      timestamp: Date.now(),
-      bidder: {
-        name: bidderRequest.bidderCode,
-        request: {
-          method: bidderRequest?.nwMonitor?.reqMethod,
-          isOverride: bidderRequest?.nwMonitor?.reqOverride,
-          endPoint: bidderRequest?.nwMonitor?.reqEndPoint
+    function findMatch(arr) {
+      for (let i = 0; i < arr.length; i++) {
+        if (device[arr[i]]()) {
+          return arr[i]
         }
-      },
-      nw: {
-        evaluated: {},
-        raw: {}
-      },
-      serverLatency: latency || {},
-      requestUrlPayloadLength: bidderRequest?.nwMonitor?.requestUrlPayloadLength,
-      t: PM_Network_POC.isBidTimeout(bidderRequest) ? 1 : 0,
-      db: perfResource?.name?.length ? 0 : 1
+      }
+      return 'others';
     };
 
-    // output.bidder = {
-    //   name: sspConfig.name,
-    //   key: sspConfig.key
-    // };
+    function find(needle) {
+      return includes(userAgent, needle);
+    };
 
-    PM_Network_POC.statHatParameters.forEach(parameter => {
-      const value = PM_Network_POC.getTimeValue(
-        perfResource[parameter.timeEndKey],
-        perfResource[parameter.timeStartKey]
-      );
-      if (value > 0) {
-        output.nw.evaluated['nw_' + parameter.key] = value;
+    function includes(haystack, needle) {
+      return haystack.indexOf(needle) !== -1;
+    };
+
+    // android
+    device.android = function() {
+      return !device.windows() && find('android');
+    };
+
+    device.androidPhone = function() {
+      return device.android() && find('mobile');
+    };
+
+    device.androidTablet = function() {
+      return device.android() && !find('mobile');
+    };
+
+    // apple
+    device.iphone = function() {
+      return !device.windows() && find('iphone');
+    };
+
+    device.ipad = function() {
+      const iPadOS13Up =
+        navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1
+      return find('ipad') || iPadOS13Up;
+    };
+
+    // windows
+    device.windows = function() {
+      return find('windows');
+    };
+
+    // mobile
+    device.mobile = function() {
+      return device.androidPhone() || device.iphone();
+    };
+
+    // tablet
+    device.tablet = function() {
+      return device.ipad() || device.androidTablet();
+    };
+
+    device.desktop = function() {
+      return !device.tablet() && !device.mobile();
+    };
+
+    return findMatch(['mobile', 'tablet', 'desktop']);
+  };
+
+  // eslint-disable-next-line camelcase
+  var PM_Network_POC = {
+
+    'timeoutCorrelators': {},
+
+    // IMP: Which namespace to be used, can be identify using,
+    // 1. Go to publisher URL.
+    // 2. Open developer tool and select console tab
+    // 3. Execute below code in the console,
+    //    3.1 window.owpbjs
+    //    If it returns object with some properties, use owpbjs as prebidNamespace
+    //    else, try changing namespace with pbjs (code: window.pbjs)
+    //    3.2 In case of IDHUB only, use code, window.ihowpbjs
+    // 4. Or connect to JS developer
+
+    'prebidNamespace': 'pbjs',
+
+    'publisherId': 1234,
+
+    // N second after auction end, get the stats for given domains
+    'executionDelayInMs': 2000,
+
+    // run the Network analysis only for the mentioned percentage of traffic
+    'testGroupPercentage': 100,
+
+    'cache': {
+      auction: {}
+    },
+
+    'statHatParameters': [
+      {
+        key: 'dns',
+        name: 'DNS Lookup',
+        timeEndKey: 'domainLookupEnd',
+        timeStartKey: 'domainLookupStart'
+      },
+      {
+        key: 'tcp',
+        name: 'TCP Connection',
+        timeEndKey: 'connectEnd',
+        timeStartKey: 'connectStart'
+      },
+      {
+        key: 'que_st',
+        name: 'Queueing and stalled',
+        timeEndKey: 'requestStart',
+        timeStartKey: 'startTime'
+      },
+      {
+        key: 'rs_wfs',
+        name: 'Request Sent and Waiting For Server',
+        timeEndKey: 'responseStart',
+        timeStartKey: 'requestStart'
+      },
+      {
+        key: 'cd',
+        name: 'Content Download',
+        timeEndKey: 'responseEnd',
+        timeStartKey: 'responseStart'
+      },
+      {
+        key: 'dur',
+        name: 'Duration',
+        timeEndKey: 'responseEnd',
+        timeStartKey: 'startTime'
       }
-    });
+    ],
 
-    output.nw.raw = perfResource;
-    PM_Network_POC.uploadTheNetworkLatencyData(output);
-  },
+    // bidders to monitor, bidderName => domain to monitor
+    // 'bidders': [
+    //   {
+    //     key: 'pm',
+    //     name: 'PubMatic',
+    //     bidderCode: 'pubmatic',
+    //     searchName: 'hbopenbid.pubmatic.com',
+    //     // reqMethod: 'POST'
+    //   },
+    //   {
+    //     // NOTE: This Object will replace dyanmically depends on dynamic change in translator endpoint config
+    //     key: 'pm',
+    //     name: 'PubMatic',
+    //     bidderCode: 'pubmatic',
+    //     searchName: 'openbidtest-ams.pubmatic.com',
+    //     // reqMethod: 'GET'
+    //   },
+    //   {
+    //     key: 'an',
+    //     name: 'AppNexus',
+    //     bidderCode: 'appnexus',
+    //     searchName: 'ib.adnxs.com'
+    //   },
+    //   {
+    //     key: 'tl',
+    //     name: 'TripleLift',
+    //     bidderCode: 'triplelift',
+    //     searchName: 'tlx.3lift.com'
+    //   },
+    //   {
+    //     key: 'rc',
+    //     name: 'Rubicon',
+    //     bidderCode: 'rubicon',
+    //     searchName: 'fastlane.rubiconproject.com'
+    //   }
+    // ],
 
-  isPubMaticBidder: function (bidderCode) {
-    return bidderCode === 'pubmatic';
-  },
+    'populateBidderDataForAuction': (bidderObj, requestObj) => {
+      PM_Network_POC.order++;
+      const bidder = PM_Network_POC.bidders.find(bidder => bidder.bidderCode === bidderObj.bidderCode);
 
-  getBidder: function (bidderRequest, perfName) {
-    return PM_Network_POC.bidders.find(bidder => {
-      // if (PM_Network_POC.isPubMaticBidder(bidder.bidderCode)) {
-      //   return perfName.includes(bidder.searchName) && bidder.bidderCode === bidderRequest.bidderCode;
-      //   // && bidder.reqMethod === bidderRequest?.nwMonitor?.reqMethod;
-      // }
-      return perfName.includes(bidder.searchName) && bidder.bidderCode === bidderRequest.bidderCode;
-    });
-  },
+      if (!bidder) {
+        PM_Network_POC.bidders.push({
+          bidderCode: bidderObj.bidderCode,
+          searchName: requestObj.url,
+          atLeastOneBidResUsedInAuction: false,
+          bids: [
+            {
+              order: PM_Network_POC.order,
+              reqPayloadCharCount: requestObj.data.length,
+              reqMethod: requestObj.method
+            }
+          ]
+        });
+      } else {
+        bidder.bids.push({
+          order: PM_Network_POC.order,
+          reqPayloadCharCount: requestObj.data.length,
+          reqMethod: requestObj.method
+        });
+      }
+    },
 
-  performNetworkAnalysis: function (bidderRequests, bidsReceived) {
-    const bidReceived = bidsReceived?.find(bidReceived => PM_Network_POC.isPubMaticBidder(bidReceived?.bidderCode));
-    //latency = latency || {};
-    let performanceResources = window?.performance?.getEntriesByType("resource");
-    let lastExecutionIndex = PM_Network_POC.lastExecutionMaxIndex;
-    //PM_Network_POC.lastExecutionMaxIndex = performanceResources.length;
+    'bidders': [],
 
-    for (let index = 0; index < bidderRequests.length; index++) {
-      const bidderRequest = bidderRequests[index];
+    'order': 0,
 
-      let perfResourceFound = false;
-      for (let i = lastExecutionIndex; i < performanceResources.length; i++) {
-        let perfResource = performanceResources[i];
+    'adUnitCount': 0,
 
-        const sspConfig = PM_Network_POC.getBidder(bidderRequest, perfResource.name);
-        if (!sspConfig) continue;
+    'setAuctionStartTime': function (args) {
+      PM_Network_POC.cache.auction.timestamp = args.timestamp;
+    },
 
-        //if (perfResource.name.includes(sspConfig.searchName)) {
-        PM_Network_POC.lastExecutionMaxIndex = i;
-        // console.log(bidderRequest, sspConfig);
-        if (PM_Network_POC.isPubMaticBidder(sspConfig.bidderCode)) {
-          const value = PM_Network_POC.getParameterByName("correlator", perfResource.name);
-          if (value == bidderRequest?.nwMonitor?.correlator) {
-            perfResourceFound = true;
-            PM_Network_POC.prepareNetworkLatencyData(perfResource, bidderRequest, bidReceived?.ext?.latency);
-            break;
-          }
-          // else {
-          //   PM_Network_POC.prepareNetworkLatencyData(perfResource, sspConfig, null);
-          // }
-        } else {
-          perfResourceFound = true;
-          PM_Network_POC.prepareNetworkLatencyData(perfResource, {}, null);
-          break;
+    // need to log domain in stats
+    'domain': (function () {
+      const replaceList = ['https://', 'http://'];
+      let hostName = window?.location?.hostname;
+      replaceList.forEach(replaceThis => {
+        hostName = hostName.replace(replaceThis, '');
+      });
+      return hostName;
+    })(),
+
+    'browserName': (function () {
+      let userAgent = navigator?.userAgent || 'others';
+      if (userAgent.match(/firefox|fxios/i)) return 'firefox';
+      if (userAgent.match(/chrome|chromium|crios/i)) return 'chrome';
+      if (userAgent.match(/safari/i)) return 'safari';
+      if (userAgent.match(/opr\//i)) return 'opera';
+      if (userAgent.match(/edg/i)) return 'edge';
+      return 'others';
+    })(),
+
+    'platform': (function () {
+      return getDeviceType();
+    })(),
+
+    // to make sure that we do not read the stats for the same network call again
+    'lastExecutionMaxIndex': 0,
+
+    'networkType': navigator?.connection?.effectiveType,
+
+    getTimeValue: function (endTime, startTime) {
+      if (isNaN(endTime) || isNaN(startTime)) return -1;
+      if (endTime === 0 || startTime === 0) return -1;
+      return endTime - startTime;
+    },
+
+    uploadTheNetworkLatencyData: function (jsonData) {
+      fetch('https://pm-network-latency-monitoring.harshad.workers.dev/', {
+        'headers': {
+          'content-type': 'application/json'
+        },
+        'method': 'POST',
+        'body': JSON.stringify(jsonData)
+      })
+        .then(res => { })
+        .then(response => { })
+        // eslint-disable-next-line handle-callback-err
+        .catch(error => { });
+    },
+
+    reset: function () {
+      this.order = 0;
+      this.bidders = [];
+      this.adUnitCount = 0;
+    },
+
+    getParameterByName: function (name, url) {
+      name = name.replace(/[\[\]]/g, '\\$&');
+      var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)');
+      var results = regex.exec(url);
+      if (!results) { return null; }
+      if (!results[2]) { return ''; }
+      return decodeURIComponent(results[2].replace(/\+/g, ' '));
+    },
+
+    'bidCallTracker': [],
+
+    prepareNetworkLatencyData: function (perfResource, bidderRequest, sspConf, latency, processedBidsCount) {
+      let currentBidCall = {};
+      let output = {
+        domain: PM_Network_POC.domain,
+        publisherId: PM_Network_POC.publisherId,
+        browser: PM_Network_POC.browserName,
+        platform: PM_Network_POC.platform,
+        adUnitCount: PM_Network_POC.adUnitCount,
+        atLeastOneBidResUsedInAuction: sspConf.atLeastOneBidResUsedInAuction,
+        bidder: {
+          name: sspConf.bidderCode,
+          requests: PM_Network_POC.bidCallTracker,
+        },
+        serverLatency: latency || {},
+        t: PM_Network_POC.timeoutCorrelators[bidderRequest?.nwMonitor?.correlator] ? 1 : 0,
+        db: perfResource?.name?.length ? 0 : 1
+      };
+
+      if (PM_Network_POC.networkType) output['networkType'] = PM_Network_POC.networkType;
+
+      currentBidCall.method = bidderRequest?.nwMonitor?.reqMethod;
+      currentBidCall.isOverride = bidderRequest?.nwMonitor?.reqOverride;
+      currentBidCall.endPoint = bidderRequest?.nwMonitor?.reqEndPoint;
+
+      currentBidCall.order = sspConf.bids[processedBidsCount - 1].order;
+      currentBidCall.reqMethod = sspConf.bids[processedBidsCount - 1].reqMethod;
+      currentBidCall.timestamp = Date.now();
+      currentBidCall.nw = {
+        evaluated: {
+          // percieved latency
+          per_lt: Date.now() - PM_Network_POC.cache.auction.timestamp
+        },
+        raw: {}
+      };
+      currentBidCall.requestUrlPayloadLength = bidderRequest?.nwMonitor?.requestUrlPayloadLength;
+      currentBidCall.reqPayloadLength = sspConf.bids[processedBidsCount - 1].reqPayloadCharCount;
+
+      PM_Network_POC.statHatParameters.forEach(parameter => {
+        const value = PM_Network_POC.getTimeValue(
+          perfResource[parameter.timeEndKey],
+          perfResource[parameter.timeStartKey]
+        );
+        if (value > 0) {
+          currentBidCall.nw.evaluated['nw_' + parameter.key] = value;
         }
-        //}
+      });
+
+      const jsonPerfResource = JSON.stringify(perfResource);
+      const raw = JSON.parse(jsonPerfResource);
+      raw.name = PM_Network_POC.removeQueryParams(perfResource.name);
+      currentBidCall.nw.raw = raw;
+      PM_Network_POC.bidCallTracker.push(currentBidCall);
+
+      if (processedBidsCount === bidderRequest.bids.length) {
+        PM_Network_POC.uploadTheNetworkLatencyData(output);
+        PM_Network_POC.bidCallTracker = [];
       }
-      if (perfResourceFound === false) {
-        PM_Network_POC.prepareNetworkLatencyData({}, bidderRequest, null);
+    },
+
+    removeQueryParams: url => url.split('?')[0],
+
+    isPubMaticBidder: function (bidderCode) {
+      return bidderCode === 'pubmatic';
+    },
+
+    getBidder: function (bidderRequest, perfName) {
+      return PM_Network_POC.bidders.find(bidder => {
+        // if (PM_Network_POC.isPubMaticBidder(bidder.bidderCode)) {
+        //   return perfName.includes(bidder.searchName) && bidder.bidderCode === bidderRequest.bidderCode;
+        //   // && bidder.reqMethod === bidderRequest?.nwMonitor?.reqMethod;
+        // }
+        return perfName.includes(bidder.searchName) && bidder.bidderCode === bidderRequest.bidderCode;
+      });
+    },
+
+    performNetworkAnalysis: function (bidderRequests, bidsReceived) {
+      const bidReceived = bidsReceived?.find(bidReceived => PM_Network_POC.isPubMaticBidder(bidReceived?.bidderCode));
+      // latency = latency || {};
+      let performanceResources = window?.performance?.getEntriesByType('resource');
+      let lastExecutionIndex = PM_Network_POC.lastExecutionMaxIndex;
+      // PM_Network_POC.lastExecutionMaxIndex = performanceResources.length;
+
+      for (let index = 0; index < bidderRequests.length; index++) {
+        const bidderRequest = bidderRequests[index];
+        let processedBidsCount = 0;
+
+        let perfResourceFound = false;
+        for (let i = lastExecutionIndex; i < performanceResources.length; i++) {
+          let perfResource = performanceResources[i];
+
+          const sspConfig = PM_Network_POC.getBidder(bidderRequest, perfResource.name);
+          if (!sspConfig) continue;
+
+          // if (perfResource.name.includes(sspConfig.searchName)) {
+          PM_Network_POC.lastExecutionMaxIndex = i;
+          // console.log(bidderRequest, sspConfig);
+          if (PM_Network_POC.isPubMaticBidder(sspConfig.bidderCode)) {
+            const value = PM_Network_POC.getParameterByName('correlator', perfResource.name);
+            if (value == bidderRequest?.nwMonitor?.correlator) {
+              perfResourceFound = true;
+              processedBidsCount++;
+              PM_Network_POC.prepareNetworkLatencyData(perfResource, bidderRequest, sspConfig, bidReceived?.ext?.latency, processedBidsCount);
+
+              if (processedBidsCount === bidderRequest.bids.length) {
+                break;
+              }
+            }
+            // else {
+            //   PM_Network_POC.prepareNetworkLatencyData(perfResource, sspConfig, null);
+            // }
+          } else {
+            perfResourceFound = true;
+            processedBidsCount++;
+            PM_Network_POC.prepareNetworkLatencyData(perfResource, bidderRequest, sspConfig, null, processedBidsCount);
+
+            if (processedBidsCount === bidderRequest.bids.length) {
+              break;
+            }
+          }
+          // }
+        }
+        if (perfResourceFound === false) {
+          processedBidsCount++;
+          PM_Network_POC.prepareNetworkLatencyData({}, bidderRequest, {}, null, processedBidsCount);
+        }
       }
     }
-  }
-};
+  };
 
-var PM_NW_POC_PREBID_NAMESPACE = PM_Network_POC.prebidNamespace;
-if (!window[PM_NW_POC_PREBID_NAMESPACE]) {
-  console.warn(`prebidNamespace used by OW is different with the configured one. Possible values could be owpbjs, ihowpbjs, pbjs. Configured prebidNamespace is ${PM_NW_POC_PREBID_NAMESPACE}`);
-}
-window[PM_NW_POC_PREBID_NAMESPACE] = window[PM_NW_POC_PREBID_NAMESPACE] || {};
-window[PM_NW_POC_PREBID_NAMESPACE].que = window[PM_NW_POC_PREBID_NAMESPACE].que || [];
-window[PM_NW_POC_PREBID_NAMESPACE].que.push(function () {
-  if (typeof window[PM_NW_POC_PREBID_NAMESPACE].onEvent === 'function') {
-    window[PM_NW_POC_PREBID_NAMESPACE].onEvent('bidTimeout', function (args) {
-      args?.forEach(bidRequest => bidRequest.t = 1);
-    });
-    window[PM_NW_POC_PREBID_NAMESPACE].onEvent('auctionEnd', function (data) {
-      var randomNumberBelow100 = Math.floor(Math.random() * 100);
-      if (randomNumberBelow100 <= PM_Network_POC.testGroupPercentage) {
-        setTimeout(
-          PM_Network_POC.performNetworkAnalysis.bind(null, data?.bidderRequests, data?.bidsReceived),
-          PM_Network_POC.executionDelayInMs
-        );
-        //PM_Network_POC.performNetworkAnalysis(bid?.ext?.latency, bid?.ext?.correlator);
-      }
-    });
-  } else {
-    console.warn(`onEvent function is not present in window.${PM_NW_POC_PREBID_NAMESPACE} object`);
+  var PM_NW_POC_PREBID_NAMESPACE = PM_Network_POC.prebidNamespace;
+  if (!window[PM_NW_POC_PREBID_NAMESPACE]) {
+    // eslint-disable-next-line no-console
+    console.warn(`prebidNamespace used by OW is different with the configured one. Possible values could be owpbjs, ihowpbjs, pbjs. Configured prebidNamespace is ${PM_NW_POC_PREBID_NAMESPACE}`);
   }
-});
+  window[PM_NW_POC_PREBID_NAMESPACE] = window[PM_NW_POC_PREBID_NAMESPACE] || {};
+  window[PM_NW_POC_PREBID_NAMESPACE].que = window[PM_NW_POC_PREBID_NAMESPACE].que || [];
+  window[PM_NW_POC_PREBID_NAMESPACE].que.push(function () {
+    if (typeof window[PM_NW_POC_PREBID_NAMESPACE].onEvent === 'function') {
+      window[PM_NW_POC_PREBID_NAMESPACE].onEvent('beforeBidderHttp', (bidderRequest, requestObject) => {
+        PM_Network_POC.populateBidderDataForAuction(bidderRequest, requestObject);
+      });
 
-// Cehck if translator request is override then add its entry in the bidder list.
-setTimeout(() => {
-  const dynamicBidderEntry = PM_Network_POC.bidders[1];
-  const overrideRequestConfig = window?.[PM_NW_POC_PREBID_NAMESPACE]?.getConfig()?.translatorGetRequest;
-  if (!overrideRequestConfig) return;
-  dynamicBidderEntry.searchName = overrideRequestConfig?.endPoint || dynamicBidderEntry.searchName;
-}, 0);
+      window[PM_NW_POC_PREBID_NAMESPACE].onEvent('bidResponse', (bidResponse) => {
+        const bidder = PM_Network_POC.bidders.find(bidder => bidder.bidderCode === bidResponse.bidderCode);
+        bidder.atLeastOneBidResUsedInAuction = true;
+      });
+
+      window[PM_NW_POC_PREBID_NAMESPACE].onEvent('auctionInit', data => {
+        if (PM_Network_POC.bidders.length > 0) PM_Network_POC.reset();
+        // needed to capture percieved latency
+        PM_Network_POC.setAuctionStartTime(data);
+      });
+
+      window[PM_NW_POC_PREBID_NAMESPACE].onEvent('bidTimeout', function (args) {
+        let uniqueBiddersBids = [...new Map(args.map(item => [item['bidder'], item])).values()];
+        if (uniqueBiddersBids) uniqueBiddersBids.forEach(bid => PM_Network_POC.timeoutCorrelators[bid.correlator] = 1);
+      });
+
+      window[PM_NW_POC_PREBID_NAMESPACE].onEvent('auctionEnd', function (data) {
+        var randomNumberBelow100 = Math.floor(Math.random() * 100);
+        if (randomNumberBelow100 <= PM_Network_POC.testGroupPercentage) {
+          PM_Network_POC.adUnitCount = data.adUnits.length;
+          setTimeout(
+            PM_Network_POC.performNetworkAnalysis.bind(null, data?.bidderRequests, data?.bidsReceived),
+            PM_Network_POC.executionDelayInMs
+          );
+          // PM_Network_POC.performNetworkAnalysis(bid?.ext?.latency, bid?.ext?.correlator);
+        }
+      });
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn(`onEvent function is not present in window.${PM_NW_POC_PREBID_NAMESPACE} object`);
+    }
+  });
+
+  // Cehck if translator request is override then add its entry in the bidder list.
+  setTimeout(() => {
+    const dynamicBidderEntry = PM_Network_POC.bidders[1];
+    const overrideRequestConfig = window?.[PM_NW_POC_PREBID_NAMESPACE]?.getConfig()?.translatorGetRequest;
+    if (!overrideRequestConfig) return;
+    dynamicBidderEntry.searchName = overrideRequestConfig?.endPoint || dynamicBidderEntry.searchName;
+  }, 0);
+})();

--- a/OnPageCode_timeout.js
+++ b/OnPageCode_timeout.js
@@ -294,12 +294,11 @@
 
       if (PM_Network_POC.networkType) output['networkType'] = PM_Network_POC.networkType;
 
-      currentBidCall.method = bidderRequest?.nwMonitor?.reqMethod;
       currentBidCall.isOverride = bidderRequest?.nwMonitor?.reqOverride;
       currentBidCall.endPoint = bidderRequest?.nwMonitor?.reqEndPoint;
 
       currentBidCall.order = sspConf.bids[processedBidsCount - 1].order;
-      currentBidCall.reqMethod = sspConf.bids[processedBidsCount - 1].reqMethod;
+      currentBidCall.method = sspConf.bids[processedBidsCount - 1].reqMethod;
       currentBidCall.nw = {
         evaluated: {
           // percieved latency

--- a/OnPageCode_timeout.js
+++ b/OnPageCode_timeout.js
@@ -134,36 +134,74 @@
       }
     ],
 
+    // bidders to monitor, bidderName => domain to monitor
+    // 'bidders': [
+    //   {
+    //     key: 'pm',
+    //     name: 'PubMatic',
+    //     bidderCode: 'pubmatic',
+    //     searchName: 'hbopenbid.pubmatic.com',
+    //     // reqMethod: 'POST'
+    //   },
+    //   {
+    //     // NOTE: This Object will replace dyanmically depends on dynamic change in translator endpoint config
+    //     key: 'pm',
+    //     name: 'PubMatic',
+    //     bidderCode: 'pubmatic',
+    //     searchName: 'openbidtest-ams.pubmatic.com',
+    //     // reqMethod: 'GET'
+    //   },
+    //   {
+    //     key: 'an',
+    //     name: 'AppNexus',
+    //     bidderCode: 'appnexus',
+    //     searchName: 'ib.adnxs.com'
+    //   },
+    //   {
+    //     key: 'tl',
+    //     name: 'TripleLift',
+    //     bidderCode: 'triplelift',
+    //     searchName: 'tlx.3lift.com'
+    //   },
+    //   {
+    //     key: 'rc',
+    //     name: 'Rubicon',
+    //     bidderCode: 'rubicon',
+    //     searchName: 'fastlane.rubiconproject.com'
+    //   }
+    // ],
+
     'populateBidderDataForAuction': (bidderObj, requestObj) => {
-      if (PM_Network_POC.bidderWhiteList.includes(bidderObj.bidderCode)) {
-        if (!Object.keys(PM_Network_POC.auction).includes(bidderObj.auctionId)) {
-          PM_Network_POC.auction[bidderObj.auctionId] = {
-            bidderRequests: []
-          };
+      PM_Network_POC.order++;
+      const bidder = PM_Network_POC.bidders.find(bidder => bidder.bidderCode === bidderObj.bidderCode);
 
-          // attempt to remove old auction data if it has already been used
-          const auctionObjKeys = Object.keys(PM_Network_POC.auction);
-          auctionObjKeys.forEach(key => {
-            if (key !== bidderObj.auctionId && PM_Network_POC.auction[key].done) delete PM_Network_POC.auction[key]
-          });
-        }
-
-        PM_Network_POC.auction[bidderObj.auctionId].bidderRequests.push({
-          order: PM_Network_POC.auction[bidderObj.auctionId].bidderRequests.length + 1,
+      if (!bidder) {
+        PM_Network_POC.bidders.push({
           bidderCode: bidderObj.bidderCode,
           searchName: requestObj.url,
-          auctionId: bidderObj.auctionId,
-          reqMethod: requestObj.method,
-          reqPayloadCharCount: requestObj.data.length
+          atLeastOneBidResUsedInAuction: false,
+          bids: [
+            {
+              order: PM_Network_POC.order,
+              reqPayloadCharCount: requestObj.data.length,
+              reqMethod: requestObj.method
+            }
+          ]
+        });
+      } else {
+        bidder.bids.push({
+          order: PM_Network_POC.order,
+          reqPayloadCharCount: requestObj.data.length,
+          reqMethod: requestObj.method
         });
       }
     },
 
-    'auction': {},
+    'bidders': [],
 
-    'bidderResponses': [],
+    'order': 0,
 
-    'bidderWhiteList': ['pubmatic', 'appnexus', 'triplelift', 'rubicon'],
+    'adUnitCount': 0,
 
     'setAuctionStartTime': function (args) {
       PM_Network_POC.cache.auction.timestamp = args.timestamp;
@@ -205,25 +243,23 @@
     },
 
     uploadTheNetworkLatencyData: function (jsonData) {
-      // eslint-disable-next-line no-console
-      console.log('PM_Network_POC: ', PM_Network_POC);
-      // eslint-disable-next-line no-console
-      console.log('jsonData: ', jsonData);
-      // fetch('https://pm-network-latency-monitoring.harshad.workers.dev/', {
-      //   'headers': {
-      //     'content-type': 'application/json'
-      //   },
-      //   'method': 'POST',
-      //   'body': JSON.stringify(jsonData)
-      // })
-      //   .then(res => { })
-      //   .then(response => { })
-      //   // eslint-disable-next-line handle-callback-err
-      //   .catch(error => { });
+      fetch('https://pm-network-latency-monitoring.harshad.workers.dev/', {
+        'headers': {
+          'content-type': 'application/json'
+        },
+        'method': 'POST',
+        'body': JSON.stringify(jsonData)
+      })
+        .then(res => { })
+        .then(response => { })
+        // eslint-disable-next-line handle-callback-err
+        .catch(error => { });
+    },
 
-      if (PM_Network_POC.auction[jsonData.auctionId].bidderRequests.length === jsonData.bidder.order) {
-        PM_Network_POC.auction[jsonData.auctionId].done = true;
-      }
+    reset: function () {
+      this.order = 0;
+      this.bidders = [];
+      this.adUnitCount = 0;
     },
 
     getParameterByName: function (name, url) {
@@ -235,33 +271,21 @@
       return decodeURIComponent(results[2].replace(/\+/g, ' '));
     },
 
-    prepareNetworkLatencyData: function (perfResource, bidderRequest, sspConf, latency) {
+    'bidCallTracker': [],
+
+    prepareNetworkLatencyData: function (perfResource, bidderRequest, sspConf, latency, processedBidsCount) {
+      let currentBidCall = {};
       let output = {
         domain: PM_Network_POC.domain,
         publisherId: PM_Network_POC.publisherId,
         browser: PM_Network_POC.browserName,
         timestamp: Date.now(),
         platform: PM_Network_POC.platform,
-        adUnitCount: PM_Network_POC.auction[sspConf.auctionId].adUnitCount,
-        atLeastOneBidResUsedInAuction: PM_Network_POC.bidderResponses.includes(sspConf.bidderCode),
-        auctionId: sspConf.auctionId,
+        adUnitCount: PM_Network_POC.adUnitCount,
+        atLeastOneBidResUsedInAuction: sspConf.atLeastOneBidResUsedInAuction,
         bidder: {
           name: sspConf.bidderCode,
-          order: sspConf.order,
-          request: {
-            isOverride: bidderRequest?.nwMonitor?.reqOverride,
-            endPoint: sspConf.searchName,
-            method: sspConf.reqMethod,
-            requestUrlPayloadLength: sspConf.searchName.length,
-            reqPayloadLength: sspConf.reqPayloadCharCount
-          }
-        },
-        nw: {
-          evaluated: {
-            // percieved latency
-            per_lt: Date.now() - PM_Network_POC.cache.auction.timestamp
-          },
-          raw: {}
+          requests: PM_Network_POC.bidCallTracker,
         },
         serverLatency: latency || {},
         t: PM_Network_POC.timeoutCorrelators[bidderRequest?.nwMonitor?.correlator] ? 1 : 0,
@@ -270,22 +294,41 @@
 
       if (PM_Network_POC.networkType) output['networkType'] = PM_Network_POC.networkType;
 
+      currentBidCall.isOverride = bidderRequest?.nwMonitor?.reqOverride;
+      currentBidCall.endPoint = bidderRequest?.nwMonitor?.reqEndPoint;
+
+      currentBidCall.order = sspConf.bids[processedBidsCount - 1].order;
+      currentBidCall.method = sspConf.bids[processedBidsCount - 1].reqMethod;
+      currentBidCall.nw = {
+        evaluated: {
+          // percieved latency
+          per_lt: Date.now() - PM_Network_POC.cache.auction.timestamp
+        },
+        raw: {}
+      };
+      currentBidCall.requestUrlPayloadLength = bidderRequest?.nwMonitor?.requestUrlPayloadLength;
+      currentBidCall.reqPayloadLength = sspConf.bids[processedBidsCount - 1].reqPayloadCharCount;
+
       PM_Network_POC.statHatParameters.forEach(parameter => {
         const value = PM_Network_POC.getTimeValue(
           perfResource[parameter.timeEndKey],
           perfResource[parameter.timeStartKey]
         );
         if (value > 0) {
-          output.nw.evaluated['nw_' + parameter.key] = value;
+          currentBidCall.nw.evaluated['nw_' + parameter.key] = value;
         }
       });
 
       const jsonPerfResource = JSON.stringify(perfResource);
       const raw = JSON.parse(jsonPerfResource);
       raw.name = PM_Network_POC.removeQueryParams(perfResource.name);
-      output.nw.raw = raw;
+      currentBidCall.nw.raw = raw;
+      PM_Network_POC.bidCallTracker.push(currentBidCall);
 
-      PM_Network_POC.uploadTheNetworkLatencyData(output);
+      if (processedBidsCount === bidderRequest.bids.length) {
+        PM_Network_POC.uploadTheNetworkLatencyData(output);
+        PM_Network_POC.bidCallTracker = [];
+      }
     },
 
     removeQueryParams: url => url.split('?')[0],
@@ -294,23 +337,32 @@
       return bidderCode === 'pubmatic';
     },
 
+    getBidder: function (bidderRequest, perfName) {
+      return PM_Network_POC.bidders.find(bidder => {
+        // if (PM_Network_POC.isPubMaticBidder(bidder.bidderCode)) {
+        //   return perfName.includes(bidder.searchName) && bidder.bidderCode === bidderRequest.bidderCode;
+        //   // && bidder.reqMethod === bidderRequest?.nwMonitor?.reqMethod;
+        // }
+        return perfName.includes(bidder.searchName) && bidder.bidderCode === bidderRequest.bidderCode;
+      });
+    },
+
     performNetworkAnalysis: function (bidderRequests, bidsReceived) {
-      const auctionId = bidderRequests[0].auctionId;
       const bidReceived = bidsReceived?.find(bidReceived => PM_Network_POC.isPubMaticBidder(bidReceived?.bidderCode));
       // latency = latency || {};
       let performanceResources = window?.performance?.getEntriesByType('resource');
       let lastExecutionIndex = PM_Network_POC.lastExecutionMaxIndex;
       // PM_Network_POC.lastExecutionMaxIndex = performanceResources.length;
 
-      for (let index = 0; index < PM_Network_POC?.auction[auctionId].bidderRequests.length; index++) {
-        const nwBidderRequest = PM_Network_POC.auction[auctionId].bidderRequests[index];
-        const bidderRequest = bidderRequests.find(bidder => bidder.bidderCode === nwBidderRequest.bidderCode);
+      for (let index = 0; index < bidderRequests.length; index++) {
+        const bidderRequest = bidderRequests[index];
+        let processedBidsCount = 0;
 
         let perfResourceFound = false;
         for (let i = lastExecutionIndex; i < performanceResources.length; i++) {
           let perfResource = performanceResources[i];
 
-          const sspConfig = perfResource.name.includes(nwBidderRequest.searchName) ? nwBidderRequest : false;
+          const sspConfig = PM_Network_POC.getBidder(bidderRequest, perfResource.name);
           if (!sspConfig) continue;
 
           // if (perfResource.name.includes(sspConfig.searchName)) {
@@ -320,23 +372,30 @@
             const value = PM_Network_POC.getParameterByName('correlator', perfResource.name);
             if (value == bidderRequest?.nwMonitor?.correlator) {
               perfResourceFound = true;
-              PM_Network_POC.prepareNetworkLatencyData(perfResource, bidderRequest, sspConfig, bidReceived?.ext?.latency);
+              processedBidsCount++;
+              PM_Network_POC.prepareNetworkLatencyData(perfResource, bidderRequest, sspConfig, bidReceived?.ext?.latency, processedBidsCount);
 
-              break;
+              if (processedBidsCount === bidderRequest.bids.length) {
+                break;
+              }
             }
             // else {
             //   PM_Network_POC.prepareNetworkLatencyData(perfResource, sspConfig, null);
             // }
           } else {
             perfResourceFound = true;
-            PM_Network_POC.prepareNetworkLatencyData(perfResource, bidderRequest, sspConfig, null);
+            processedBidsCount++;
+            PM_Network_POC.prepareNetworkLatencyData(perfResource, bidderRequest, sspConfig, null, processedBidsCount);
 
-            break;
+            if (processedBidsCount === bidderRequest.bids.length) {
+              break;
+            }
           }
           // }
         }
         if (perfResourceFound === false) {
-          PM_Network_POC.prepareNetworkLatencyData({}, bidderRequest, {}, null);
+          processedBidsCount++;
+          PM_Network_POC.prepareNetworkLatencyData({}, bidderRequest, {}, null, processedBidsCount);
         }
       }
     }
@@ -356,10 +415,12 @@
       });
 
       window[PM_NW_POC_PREBID_NAMESPACE].onEvent('bidResponse', (bidResponse) => {
-        if (PM_Network_POC.bidderResponses.indexOf(bidResponse.bidderCode) === -1) PM_Network_POC.bidderResponses.push(bidResponse.bidderCode);
+        const bidder = PM_Network_POC.bidders.find(bidder => bidder.bidderCode === bidResponse.bidderCode);
+        bidder.atLeastOneBidResUsedInAuction = true;
       });
 
       window[PM_NW_POC_PREBID_NAMESPACE].onEvent('auctionInit', data => {
+        if (PM_Network_POC.bidders.length > 0) PM_Network_POC.reset();
         // needed to capture percieved latency
         PM_Network_POC.setAuctionStartTime(data);
       });
@@ -372,8 +433,7 @@
       window[PM_NW_POC_PREBID_NAMESPACE].onEvent('auctionEnd', function (data) {
         var randomNumberBelow100 = Math.floor(Math.random() * 100);
         if (randomNumberBelow100 <= PM_Network_POC.testGroupPercentage) {
-          // PM_Network_POC.adUnitCount = data.adUnits.length;
-          PM_Network_POC.auction[data.auctionId].adUnitCount = data.adUnits.length;
+          PM_Network_POC.adUnitCount = data.adUnits.length;
           setTimeout(
             PM_Network_POC.performNetworkAnalysis.bind(null, data?.bidderRequests, data?.bidsReceived),
             PM_Network_POC.executionDelayInMs
@@ -388,10 +448,10 @@
   });
 
   // Cehck if translator request is override then add its entry in the bidder list.
-  // setTimeout(() => {
-  //   const dynamicBidderEntry = PM_Network_POC.bidderRequests[1];
-  //   const overrideRequestConfig = window?.[PM_NW_POC_PREBID_NAMESPACE]?.getConfig()?.translatorGetRequest;
-  //   if (!overrideRequestConfig) return;
-  //   dynamicBidderEntry.searchName = overrideRequestConfig?.endPoint || dynamicBidderEntry.searchName;
-  // }, 0);
+  setTimeout(() => {
+    const dynamicBidderEntry = PM_Network_POC.bidders[1];
+    const overrideRequestConfig = window?.[PM_NW_POC_PREBID_NAMESPACE]?.getConfig()?.translatorGetRequest;
+    if (!overrideRequestConfig) return;
+    dynamicBidderEntry.searchName = overrideRequestConfig?.endPoint || dynamicBidderEntry.searchName;
+  }, 0);
 })();

--- a/OnPageCode_timeout.js
+++ b/OnPageCode_timeout.js
@@ -68,6 +68,9 @@
 
   // eslint-disable-next-line camelcase
   var PM_Network_POC = {
+
+    'timeoutCorrelators': {},
+
     // IMP: Which namespace to be used, can be identify using,
     // 1. Go to publisher URL.
     // 2. Open developer tool and select console tab
@@ -131,36 +134,74 @@
       }
     ],
 
+    // bidders to monitor, bidderName => domain to monitor
+    // 'bidders': [
+    //   {
+    //     key: 'pm',
+    //     name: 'PubMatic',
+    //     bidderCode: 'pubmatic',
+    //     searchName: 'hbopenbid.pubmatic.com',
+    //     // reqMethod: 'POST'
+    //   },
+    //   {
+    //     // NOTE: This Object will replace dyanmically depends on dynamic change in translator endpoint config
+    //     key: 'pm',
+    //     name: 'PubMatic',
+    //     bidderCode: 'pubmatic',
+    //     searchName: 'openbidtest-ams.pubmatic.com',
+    //     // reqMethod: 'GET'
+    //   },
+    //   {
+    //     key: 'an',
+    //     name: 'AppNexus',
+    //     bidderCode: 'appnexus',
+    //     searchName: 'ib.adnxs.com'
+    //   },
+    //   {
+    //     key: 'tl',
+    //     name: 'TripleLift',
+    //     bidderCode: 'triplelift',
+    //     searchName: 'tlx.3lift.com'
+    //   },
+    //   {
+    //     key: 'rc',
+    //     name: 'Rubicon',
+    //     bidderCode: 'rubicon',
+    //     searchName: 'fastlane.rubiconproject.com'
+    //   }
+    // ],
+
     'populateBidderDataForAuction': (bidderObj, requestObj) => {
-      if (PM_Network_POC.bidderWhiteList.includes(bidderObj.bidderCode)) {
-        if (!Object.keys(PM_Network_POC.auction).includes(bidderObj.auctionId)) {
-          PM_Network_POC.auction[bidderObj.auctionId] = {
-            bidderRequests: []
-          };
+      PM_Network_POC.order++;
+      const bidder = PM_Network_POC.bidders.find(bidder => bidder.bidderCode === bidderObj.bidderCode);
 
-          // attempt to remove old auction data if it has already been used
-          const auctionObjKeys = Object.keys(PM_Network_POC.auction);
-          auctionObjKeys.forEach(key => {
-            if (key !== bidderObj.auctionId && PM_Network_POC.auction[key].done) delete PM_Network_POC.auction[key]
-          });
-        }
-
-        PM_Network_POC.auction[bidderObj.auctionId].bidderRequests.push({
-          order: PM_Network_POC.auction[bidderObj.auctionId].bidderRequests.length + 1,
+      if (!bidder) {
+        PM_Network_POC.bidders.push({
           bidderCode: bidderObj.bidderCode,
           searchName: requestObj.url,
-          auctionId: bidderObj.auctionId,
-          reqMethod: requestObj.method,
-          reqPayloadCharCount: requestObj.data.length
+          atLeastOneBidResUsedInAuction: false,
+          bids: [
+            {
+              order: PM_Network_POC.order,
+              reqPayloadCharCount: requestObj.data.length,
+              reqMethod: requestObj.method
+            }
+          ]
+        });
+      } else {
+        bidder.bids.push({
+          order: PM_Network_POC.order,
+          reqPayloadCharCount: requestObj.data.length,
+          reqMethod: requestObj.method
         });
       }
     },
 
-    'auction': {},
+    'bidders': [],
 
-    'bidderResponses': [],
+    'order': 0,
 
-    'bidderWhiteList': ['pubmatic', 'appnexus', 'triplelift', 'rubicon'],
+    'adUnitCount': 0,
 
     'setAuctionStartTime': function (args) {
       PM_Network_POC.cache.auction.timestamp = args.timestamp;
@@ -213,10 +254,12 @@
         .then(response => { })
         // eslint-disable-next-line handle-callback-err
         .catch(error => { });
+    },
 
-      if (PM_Network_POC.auction[jsonData.auctionId].bidderRequests.length === jsonData.bidder.order) {
-        PM_Network_POC.auction[jsonData.auctionId].done = true;
-      }
+    reset: function () {
+      this.order = 0;
+      this.bidders = [];
+      this.adUnitCount = 0;
     },
 
     getParameterByName: function (name, url) {
@@ -228,44 +271,43 @@
       return decodeURIComponent(results[2].replace(/\+/g, ' '));
     },
 
-    isBidTimeout: function (bidderRequest) {
-      return bidderRequest?.bids?.some(bid => bid.t === 1);
-    },
+    'bidCallTracker': [],
 
-    prepareNetworkLatencyData: function (perfResource, bidderRequest, sspConf, latency) {
+    prepareNetworkLatencyData: function (perfResource, bidderRequest, sspConf, latency, processedBidsCount) {
+      let currentBidCall = {};
       let output = {
         domain: PM_Network_POC.domain,
         publisherId: PM_Network_POC.publisherId,
         browser: PM_Network_POC.browserName,
         timestamp: Date.now(),
         platform: PM_Network_POC.platform,
-        adUnitCount: PM_Network_POC.auction[sspConf.auctionId].adUnitCount,
-        atLeastOneBidResUsedInAuction: PM_Network_POC.bidderResponses.includes(sspConf.bidderCode),
-        auctionId: sspConf.auctionId,
+        adUnitCount: PM_Network_POC.adUnitCount,
+        atLeastOneBidResUsedInAuction: sspConf.atLeastOneBidResUsedInAuction,
         bidder: {
           name: sspConf.bidderCode,
-          order: sspConf.order,
-          request: {
-            isOverride: bidderRequest?.nwMonitor?.reqOverride,
-            endPoint: sspConf.searchName,
-            method: sspConf.reqMethod,
-            requestUrlPayloadLength: sspConf.searchName.length,
-            reqPayloadLength: sspConf.reqPayloadCharCount
-          }
-        },
-        nw: {
-          evaluated: {
-            // percieved latency
-            per_lt: Date.now() - PM_Network_POC.cache.auction.timestamp
-          },
-          raw: {}
+          requests: PM_Network_POC.bidCallTracker,
         },
         serverLatency: latency || {},
-        t: PM_Network_POC.isBidTimeout(bidderRequest) ? 1 : 0,
+        t: PM_Network_POC.timeoutCorrelators[bidderRequest?.nwMonitor?.correlator] ? 1 : 0,
         db: perfResource?.name?.length ? 0 : 1
       };
 
       if (PM_Network_POC.networkType) output['networkType'] = PM_Network_POC.networkType;
+
+      currentBidCall.isOverride = bidderRequest?.nwMonitor?.reqOverride;
+      currentBidCall.endPoint = bidderRequest?.nwMonitor?.reqEndPoint;
+
+      currentBidCall.order = sspConf.bids[processedBidsCount - 1].order;
+      currentBidCall.method = sspConf.bids[processedBidsCount - 1].reqMethod;
+      currentBidCall.nw = {
+        evaluated: {
+          // percieved latency
+          per_lt: Date.now() - PM_Network_POC.cache.auction.timestamp
+        },
+        raw: {}
+      };
+      currentBidCall.requestUrlPayloadLength = bidderRequest?.nwMonitor?.requestUrlPayloadLength;
+      currentBidCall.reqPayloadLength = sspConf.bids[processedBidsCount - 1].reqPayloadCharCount;
 
       PM_Network_POC.statHatParameters.forEach(parameter => {
         const value = PM_Network_POC.getTimeValue(
@@ -273,16 +315,20 @@
           perfResource[parameter.timeStartKey]
         );
         if (value > 0) {
-          output.nw.evaluated['nw_' + parameter.key] = value;
+          currentBidCall.nw.evaluated['nw_' + parameter.key] = value;
         }
       });
 
       const jsonPerfResource = JSON.stringify(perfResource);
       const raw = JSON.parse(jsonPerfResource);
       raw.name = PM_Network_POC.removeQueryParams(perfResource.name);
-      output.nw.raw = raw;
+      currentBidCall.nw.raw = raw;
+      PM_Network_POC.bidCallTracker.push(currentBidCall);
 
-      PM_Network_POC.uploadTheNetworkLatencyData(output);
+      if (processedBidsCount === bidderRequest.bids.length) {
+        PM_Network_POC.uploadTheNetworkLatencyData(output);
+        PM_Network_POC.bidCallTracker = [];
+      }
     },
 
     removeQueryParams: url => url.split('?')[0],
@@ -291,23 +337,32 @@
       return bidderCode === 'pubmatic';
     },
 
+    getBidder: function (bidderRequest, perfName) {
+      return PM_Network_POC.bidders.find(bidder => {
+        // if (PM_Network_POC.isPubMaticBidder(bidder.bidderCode)) {
+        //   return perfName.includes(bidder.searchName) && bidder.bidderCode === bidderRequest.bidderCode;
+        //   // && bidder.reqMethod === bidderRequest?.nwMonitor?.reqMethod;
+        // }
+        return perfName.includes(bidder.searchName) && bidder.bidderCode === bidderRequest.bidderCode;
+      });
+    },
+
     performNetworkAnalysis: function (bidderRequests, bidsReceived) {
-      const auctionId = bidderRequests[0].auctionId;
       const bidReceived = bidsReceived?.find(bidReceived => PM_Network_POC.isPubMaticBidder(bidReceived?.bidderCode));
       // latency = latency || {};
       let performanceResources = window?.performance?.getEntriesByType('resource');
       let lastExecutionIndex = PM_Network_POC.lastExecutionMaxIndex;
       // PM_Network_POC.lastExecutionMaxIndex = performanceResources.length;
 
-      for (let index = 0; index < PM_Network_POC?.auction[auctionId].bidderRequests.length; index++) {
-        const nwBidderRequest = PM_Network_POC.auction[auctionId].bidderRequests[index];
-        const bidderRequest = bidderRequests.find(bidder => bidder.bidderCode === nwBidderRequest.bidderCode);
+      for (let index = 0; index < bidderRequests.length; index++) {
+        const bidderRequest = bidderRequests[index];
+        let processedBidsCount = 0;
 
         let perfResourceFound = false;
         for (let i = lastExecutionIndex; i < performanceResources.length; i++) {
           let perfResource = performanceResources[i];
 
-          const sspConfig = perfResource.name.includes(nwBidderRequest.searchName) ? nwBidderRequest : false;
+          const sspConfig = PM_Network_POC.getBidder(bidderRequest, perfResource.name);
           if (!sspConfig) continue;
 
           // if (perfResource.name.includes(sspConfig.searchName)) {
@@ -317,23 +372,30 @@
             const value = PM_Network_POC.getParameterByName('correlator', perfResource.name);
             if (value == bidderRequest?.nwMonitor?.correlator) {
               perfResourceFound = true;
-              PM_Network_POC.prepareNetworkLatencyData(perfResource, bidderRequest, sspConfig, bidReceived?.ext?.latency);
+              processedBidsCount++;
+              PM_Network_POC.prepareNetworkLatencyData(perfResource, bidderRequest, sspConfig, bidReceived?.ext?.latency, processedBidsCount);
 
-              break;
+              if (processedBidsCount === bidderRequest.bids.length) {
+                break;
+              }
             }
             // else {
             //   PM_Network_POC.prepareNetworkLatencyData(perfResource, sspConfig, null);
             // }
           } else {
             perfResourceFound = true;
-            PM_Network_POC.prepareNetworkLatencyData(perfResource, bidderRequest, sspConfig, null);
+            processedBidsCount++;
+            PM_Network_POC.prepareNetworkLatencyData(perfResource, bidderRequest, sspConfig, null, processedBidsCount);
 
-            break;
+            if (processedBidsCount === bidderRequest.bids.length) {
+              break;
+            }
           }
           // }
         }
         if (perfResourceFound === false) {
-          PM_Network_POC.prepareNetworkLatencyData({}, bidderRequest, {}, null);
+          processedBidsCount++;
+          PM_Network_POC.prepareNetworkLatencyData({}, bidderRequest, {}, null, processedBidsCount);
         }
       }
     }
@@ -353,23 +415,25 @@
       });
 
       window[PM_NW_POC_PREBID_NAMESPACE].onEvent('bidResponse', (bidResponse) => {
-        if (PM_Network_POC.bidderResponses.indexOf(bidResponse.bidderCode) === -1) PM_Network_POC.bidderResponses.push(bidResponse.bidderCode);
+        const bidder = PM_Network_POC.bidders.find(bidder => bidder.bidderCode === bidResponse.bidderCode);
+        bidder.atLeastOneBidResUsedInAuction = true;
       });
 
       window[PM_NW_POC_PREBID_NAMESPACE].onEvent('auctionInit', data => {
+        if (PM_Network_POC.bidders.length > 0) PM_Network_POC.reset();
         // needed to capture percieved latency
         PM_Network_POC.setAuctionStartTime(data);
       });
 
       window[PM_NW_POC_PREBID_NAMESPACE].onEvent('bidTimeout', function (args) {
-        args?.forEach(bidRequest => bidRequest.t = 1);
+        let uniqueBiddersBids = [...new Map(args.map(item => [item['bidder'], item])).values()];
+        if (uniqueBiddersBids) uniqueBiddersBids.forEach(bid => PM_Network_POC.timeoutCorrelators[bid.correlator] = 1);
       });
 
       window[PM_NW_POC_PREBID_NAMESPACE].onEvent('auctionEnd', function (data) {
         var randomNumberBelow100 = Math.floor(Math.random() * 100);
         if (randomNumberBelow100 <= PM_Network_POC.testGroupPercentage) {
-          // PM_Network_POC.adUnitCount = data.adUnits.length;
-          PM_Network_POC.auction[data.auctionId].adUnitCount = data.adUnits.length;
+          PM_Network_POC.adUnitCount = data.adUnits.length;
           setTimeout(
             PM_Network_POC.performNetworkAnalysis.bind(null, data?.bidderRequests, data?.bidsReceived),
             PM_Network_POC.executionDelayInMs
@@ -384,10 +448,10 @@
   });
 
   // Cehck if translator request is override then add its entry in the bidder list.
-  // setTimeout(() => {
-  //   const dynamicBidderEntry = PM_Network_POC.bidderRequests[1];
-  //   const overrideRequestConfig = window?.[PM_NW_POC_PREBID_NAMESPACE]?.getConfig()?.translatorGetRequest;
-  //   if (!overrideRequestConfig) return;
-  //   dynamicBidderEntry.searchName = overrideRequestConfig?.endPoint || dynamicBidderEntry.searchName;
-  // }, 0);
+  setTimeout(() => {
+    const dynamicBidderEntry = PM_Network_POC.bidders[1];
+    const overrideRequestConfig = window?.[PM_NW_POC_PREBID_NAMESPACE]?.getConfig()?.translatorGetRequest;
+    if (!overrideRequestConfig) return;
+    dynamicBidderEntry.searchName = overrideRequestConfig?.endPoint || dynamicBidderEntry.searchName;
+  }, 0);
 })();

--- a/OnPageCode_timeout.js
+++ b/OnPageCode_timeout.js
@@ -68,9 +68,6 @@
 
   // eslint-disable-next-line camelcase
   var PM_Network_POC = {
-
-    'timeoutCorrelators': {},
-
     // IMP: Which namespace to be used, can be identify using,
     // 1. Go to publisher URL.
     // 2. Open developer tool and select console tab
@@ -134,74 +131,36 @@
       }
     ],
 
-    // bidders to monitor, bidderName => domain to monitor
-    // 'bidders': [
-    //   {
-    //     key: 'pm',
-    //     name: 'PubMatic',
-    //     bidderCode: 'pubmatic',
-    //     searchName: 'hbopenbid.pubmatic.com',
-    //     // reqMethod: 'POST'
-    //   },
-    //   {
-    //     // NOTE: This Object will replace dyanmically depends on dynamic change in translator endpoint config
-    //     key: 'pm',
-    //     name: 'PubMatic',
-    //     bidderCode: 'pubmatic',
-    //     searchName: 'openbidtest-ams.pubmatic.com',
-    //     // reqMethod: 'GET'
-    //   },
-    //   {
-    //     key: 'an',
-    //     name: 'AppNexus',
-    //     bidderCode: 'appnexus',
-    //     searchName: 'ib.adnxs.com'
-    //   },
-    //   {
-    //     key: 'tl',
-    //     name: 'TripleLift',
-    //     bidderCode: 'triplelift',
-    //     searchName: 'tlx.3lift.com'
-    //   },
-    //   {
-    //     key: 'rc',
-    //     name: 'Rubicon',
-    //     bidderCode: 'rubicon',
-    //     searchName: 'fastlane.rubiconproject.com'
-    //   }
-    // ],
-
     'populateBidderDataForAuction': (bidderObj, requestObj) => {
-      PM_Network_POC.order++;
-      const bidder = PM_Network_POC.bidders.find(bidder => bidder.bidderCode === bidderObj.bidderCode);
+      if (PM_Network_POC.bidderWhiteList.includes(bidderObj.bidderCode)) {
+        if (!Object.keys(PM_Network_POC.auction).includes(bidderObj.auctionId)) {
+          PM_Network_POC.auction[bidderObj.auctionId] = {
+            bidderRequests: []
+          };
 
-      if (!bidder) {
-        PM_Network_POC.bidders.push({
+          // attempt to remove old auction data if it has already been used
+          const auctionObjKeys = Object.keys(PM_Network_POC.auction);
+          auctionObjKeys.forEach(key => {
+            if (key !== bidderObj.auctionId && PM_Network_POC.auction[key].done) delete PM_Network_POC.auction[key]
+          });
+        }
+
+        PM_Network_POC.auction[bidderObj.auctionId].bidderRequests.push({
+          order: PM_Network_POC.auction[bidderObj.auctionId].bidderRequests.length + 1,
           bidderCode: bidderObj.bidderCode,
           searchName: requestObj.url,
-          atLeastOneBidResUsedInAuction: false,
-          bids: [
-            {
-              order: PM_Network_POC.order,
-              reqPayloadCharCount: requestObj.data.length,
-              reqMethod: requestObj.method
-            }
-          ]
-        });
-      } else {
-        bidder.bids.push({
-          order: PM_Network_POC.order,
-          reqPayloadCharCount: requestObj.data.length,
-          reqMethod: requestObj.method
+          auctionId: bidderObj.auctionId,
+          reqMethod: requestObj.method,
+          reqPayloadCharCount: requestObj.data.length
         });
       }
     },
 
-    'bidders': [],
+    'auction': {},
 
-    'order': 0,
+    'bidderResponses': [],
 
-    'adUnitCount': 0,
+    'bidderWhiteList': ['pubmatic', 'appnexus', 'triplelift', 'rubicon'],
 
     'setAuctionStartTime': function (args) {
       PM_Network_POC.cache.auction.timestamp = args.timestamp;
@@ -254,12 +213,10 @@
         .then(response => { })
         // eslint-disable-next-line handle-callback-err
         .catch(error => { });
-    },
 
-    reset: function () {
-      this.order = 0;
-      this.bidders = [];
-      this.adUnitCount = 0;
+      if (PM_Network_POC.auction[jsonData.auctionId].bidderRequests.length === jsonData.bidder.order) {
+        PM_Network_POC.auction[jsonData.auctionId].done = true;
+      }
     },
 
     getParameterByName: function (name, url) {
@@ -271,43 +228,44 @@
       return decodeURIComponent(results[2].replace(/\+/g, ' '));
     },
 
-    'bidCallTracker': [],
+    isBidTimeout: function (bidderRequest) {
+      return bidderRequest?.bids?.some(bid => bid.t === 1);
+    },
 
-    prepareNetworkLatencyData: function (perfResource, bidderRequest, sspConf, latency, processedBidsCount) {
-      let currentBidCall = {};
+    prepareNetworkLatencyData: function (perfResource, bidderRequest, sspConf, latency) {
       let output = {
         domain: PM_Network_POC.domain,
         publisherId: PM_Network_POC.publisherId,
         browser: PM_Network_POC.browserName,
         timestamp: Date.now(),
         platform: PM_Network_POC.platform,
-        adUnitCount: PM_Network_POC.adUnitCount,
-        atLeastOneBidResUsedInAuction: sspConf.atLeastOneBidResUsedInAuction,
+        adUnitCount: PM_Network_POC.auction[sspConf.auctionId].adUnitCount,
+        atLeastOneBidResUsedInAuction: PM_Network_POC.bidderResponses.includes(sspConf.bidderCode),
+        auctionId: sspConf.auctionId,
         bidder: {
           name: sspConf.bidderCode,
-          requests: PM_Network_POC.bidCallTracker,
+          order: sspConf.order,
+          request: {
+            isOverride: bidderRequest?.nwMonitor?.reqOverride,
+            endPoint: sspConf.searchName,
+            method: sspConf.reqMethod,
+            requestUrlPayloadLength: sspConf.searchName.length,
+            reqPayloadLength: sspConf.reqPayloadCharCount
+          }
+        },
+        nw: {
+          evaluated: {
+            // percieved latency
+            per_lt: Date.now() - PM_Network_POC.cache.auction.timestamp
+          },
+          raw: {}
         },
         serverLatency: latency || {},
-        t: PM_Network_POC.timeoutCorrelators[bidderRequest?.nwMonitor?.correlator] ? 1 : 0,
+        t: PM_Network_POC.isBidTimeout(bidderRequest) ? 1 : 0,
         db: perfResource?.name?.length ? 0 : 1
       };
 
       if (PM_Network_POC.networkType) output['networkType'] = PM_Network_POC.networkType;
-
-      currentBidCall.isOverride = bidderRequest?.nwMonitor?.reqOverride;
-      currentBidCall.endPoint = bidderRequest?.nwMonitor?.reqEndPoint;
-
-      currentBidCall.order = sspConf.bids[processedBidsCount - 1].order;
-      currentBidCall.method = sspConf.bids[processedBidsCount - 1].reqMethod;
-      currentBidCall.nw = {
-        evaluated: {
-          // percieved latency
-          per_lt: Date.now() - PM_Network_POC.cache.auction.timestamp
-        },
-        raw: {}
-      };
-      currentBidCall.requestUrlPayloadLength = bidderRequest?.nwMonitor?.requestUrlPayloadLength;
-      currentBidCall.reqPayloadLength = sspConf.bids[processedBidsCount - 1].reqPayloadCharCount;
 
       PM_Network_POC.statHatParameters.forEach(parameter => {
         const value = PM_Network_POC.getTimeValue(
@@ -315,20 +273,16 @@
           perfResource[parameter.timeStartKey]
         );
         if (value > 0) {
-          currentBidCall.nw.evaluated['nw_' + parameter.key] = value;
+          output.nw.evaluated['nw_' + parameter.key] = value;
         }
       });
 
       const jsonPerfResource = JSON.stringify(perfResource);
       const raw = JSON.parse(jsonPerfResource);
       raw.name = PM_Network_POC.removeQueryParams(perfResource.name);
-      currentBidCall.nw.raw = raw;
-      PM_Network_POC.bidCallTracker.push(currentBidCall);
+      output.nw.raw = raw;
 
-      if (processedBidsCount === bidderRequest.bids.length) {
-        PM_Network_POC.uploadTheNetworkLatencyData(output);
-        PM_Network_POC.bidCallTracker = [];
-      }
+      PM_Network_POC.uploadTheNetworkLatencyData(output);
     },
 
     removeQueryParams: url => url.split('?')[0],
@@ -337,32 +291,23 @@
       return bidderCode === 'pubmatic';
     },
 
-    getBidder: function (bidderRequest, perfName) {
-      return PM_Network_POC.bidders.find(bidder => {
-        // if (PM_Network_POC.isPubMaticBidder(bidder.bidderCode)) {
-        //   return perfName.includes(bidder.searchName) && bidder.bidderCode === bidderRequest.bidderCode;
-        //   // && bidder.reqMethod === bidderRequest?.nwMonitor?.reqMethod;
-        // }
-        return perfName.includes(bidder.searchName) && bidder.bidderCode === bidderRequest.bidderCode;
-      });
-    },
-
     performNetworkAnalysis: function (bidderRequests, bidsReceived) {
+      const auctionId = bidderRequests[0].auctionId;
       const bidReceived = bidsReceived?.find(bidReceived => PM_Network_POC.isPubMaticBidder(bidReceived?.bidderCode));
       // latency = latency || {};
       let performanceResources = window?.performance?.getEntriesByType('resource');
       let lastExecutionIndex = PM_Network_POC.lastExecutionMaxIndex;
       // PM_Network_POC.lastExecutionMaxIndex = performanceResources.length;
 
-      for (let index = 0; index < bidderRequests.length; index++) {
-        const bidderRequest = bidderRequests[index];
-        let processedBidsCount = 0;
+      for (let index = 0; index < PM_Network_POC?.auction[auctionId].bidderRequests.length; index++) {
+        const nwBidderRequest = PM_Network_POC.auction[auctionId].bidderRequests[index];
+        const bidderRequest = bidderRequests.find(bidder => bidder.bidderCode === nwBidderRequest.bidderCode);
 
         let perfResourceFound = false;
         for (let i = lastExecutionIndex; i < performanceResources.length; i++) {
           let perfResource = performanceResources[i];
 
-          const sspConfig = PM_Network_POC.getBidder(bidderRequest, perfResource.name);
+          const sspConfig = perfResource.name.includes(nwBidderRequest.searchName) ? nwBidderRequest : false;
           if (!sspConfig) continue;
 
           // if (perfResource.name.includes(sspConfig.searchName)) {
@@ -372,30 +317,23 @@
             const value = PM_Network_POC.getParameterByName('correlator', perfResource.name);
             if (value == bidderRequest?.nwMonitor?.correlator) {
               perfResourceFound = true;
-              processedBidsCount++;
-              PM_Network_POC.prepareNetworkLatencyData(perfResource, bidderRequest, sspConfig, bidReceived?.ext?.latency, processedBidsCount);
+              PM_Network_POC.prepareNetworkLatencyData(perfResource, bidderRequest, sspConfig, bidReceived?.ext?.latency);
 
-              if (processedBidsCount === bidderRequest.bids.length) {
-                break;
-              }
+              break;
             }
             // else {
             //   PM_Network_POC.prepareNetworkLatencyData(perfResource, sspConfig, null);
             // }
           } else {
             perfResourceFound = true;
-            processedBidsCount++;
-            PM_Network_POC.prepareNetworkLatencyData(perfResource, bidderRequest, sspConfig, null, processedBidsCount);
+            PM_Network_POC.prepareNetworkLatencyData(perfResource, bidderRequest, sspConfig, null);
 
-            if (processedBidsCount === bidderRequest.bids.length) {
-              break;
-            }
+            break;
           }
           // }
         }
         if (perfResourceFound === false) {
-          processedBidsCount++;
-          PM_Network_POC.prepareNetworkLatencyData({}, bidderRequest, {}, null, processedBidsCount);
+          PM_Network_POC.prepareNetworkLatencyData({}, bidderRequest, {}, null);
         }
       }
     }
@@ -415,25 +353,23 @@
       });
 
       window[PM_NW_POC_PREBID_NAMESPACE].onEvent('bidResponse', (bidResponse) => {
-        const bidder = PM_Network_POC.bidders.find(bidder => bidder.bidderCode === bidResponse.bidderCode);
-        bidder.atLeastOneBidResUsedInAuction = true;
+        if (PM_Network_POC.bidderResponses.indexOf(bidResponse.bidderCode) === -1) PM_Network_POC.bidderResponses.push(bidResponse.bidderCode);
       });
 
       window[PM_NW_POC_PREBID_NAMESPACE].onEvent('auctionInit', data => {
-        if (PM_Network_POC.bidders.length > 0) PM_Network_POC.reset();
         // needed to capture percieved latency
         PM_Network_POC.setAuctionStartTime(data);
       });
 
       window[PM_NW_POC_PREBID_NAMESPACE].onEvent('bidTimeout', function (args) {
-        let uniqueBiddersBids = [...new Map(args.map(item => [item['bidder'], item])).values()];
-        if (uniqueBiddersBids) uniqueBiddersBids.forEach(bid => PM_Network_POC.timeoutCorrelators[bid.correlator] = 1);
+        args?.forEach(bidRequest => bidRequest.t = 1);
       });
 
       window[PM_NW_POC_PREBID_NAMESPACE].onEvent('auctionEnd', function (data) {
         var randomNumberBelow100 = Math.floor(Math.random() * 100);
         if (randomNumberBelow100 <= PM_Network_POC.testGroupPercentage) {
-          PM_Network_POC.adUnitCount = data.adUnits.length;
+          // PM_Network_POC.adUnitCount = data.adUnits.length;
+          PM_Network_POC.auction[data.auctionId].adUnitCount = data.adUnits.length;
           setTimeout(
             PM_Network_POC.performNetworkAnalysis.bind(null, data?.bidderRequests, data?.bidsReceived),
             PM_Network_POC.executionDelayInMs
@@ -448,10 +384,10 @@
   });
 
   // Cehck if translator request is override then add its entry in the bidder list.
-  setTimeout(() => {
-    const dynamicBidderEntry = PM_Network_POC.bidders[1];
-    const overrideRequestConfig = window?.[PM_NW_POC_PREBID_NAMESPACE]?.getConfig()?.translatorGetRequest;
-    if (!overrideRequestConfig) return;
-    dynamicBidderEntry.searchName = overrideRequestConfig?.endPoint || dynamicBidderEntry.searchName;
-  }, 0);
+  // setTimeout(() => {
+  //   const dynamicBidderEntry = PM_Network_POC.bidderRequests[1];
+  //   const overrideRequestConfig = window?.[PM_NW_POC_PREBID_NAMESPACE]?.getConfig()?.translatorGetRequest;
+  //   if (!overrideRequestConfig) return;
+  //   dynamicBidderEntry.searchName = overrideRequestConfig?.endPoint || dynamicBidderEntry.searchName;
+  // }, 0);
 })();

--- a/OnPageCode_timeout.js
+++ b/OnPageCode_timeout.js
@@ -68,9 +68,6 @@
 
   // eslint-disable-next-line camelcase
   var PM_Network_POC = {
-
-    'timeoutCorrelators': {},
-
     // IMP: Which namespace to be used, can be identify using,
     // 1. Go to publisher URL.
     // 2. Open developer tool and select console tab
@@ -235,6 +232,10 @@
       return decodeURIComponent(results[2].replace(/\+/g, ' '));
     },
 
+    isBidTimeout: function (bidderRequest) {
+      return bidderRequest?.bids?.some(bid => bid.t === 1);
+    },
+
     prepareNetworkLatencyData: function (perfResource, bidderRequest, sspConf, latency) {
       let output = {
         domain: PM_Network_POC.domain,
@@ -264,7 +265,7 @@
           raw: {}
         },
         serverLatency: latency || {},
-        t: PM_Network_POC.timeoutCorrelators[bidderRequest?.nwMonitor?.correlator] ? 1 : 0,
+        t: PM_Network_POC.isBidTimeout(bidderRequest) ? 1 : 0,
         db: perfResource?.name?.length ? 0 : 1
       };
 
@@ -365,8 +366,7 @@
       });
 
       window[PM_NW_POC_PREBID_NAMESPACE].onEvent('bidTimeout', function (args) {
-        let uniqueBiddersBids = [...new Map(args.map(item => [item['bidder'], item])).values()];
-        if (uniqueBiddersBids) uniqueBiddersBids.forEach(bid => PM_Network_POC.timeoutCorrelators[bid.correlator] = 1);
+        args?.forEach(bidRequest => bidRequest.t = 1);
       });
 
       window[PM_NW_POC_PREBID_NAMESPACE].onEvent('auctionEnd', function (data) {

--- a/OnPageCode_timeout.js
+++ b/OnPageCode_timeout.js
@@ -279,6 +279,7 @@
         domain: PM_Network_POC.domain,
         publisherId: PM_Network_POC.publisherId,
         browser: PM_Network_POC.browserName,
+        timestamp: Date.now(),
         platform: PM_Network_POC.platform,
         adUnitCount: PM_Network_POC.adUnitCount,
         atLeastOneBidResUsedInAuction: sspConf.atLeastOneBidResUsedInAuction,
@@ -299,7 +300,6 @@
 
       currentBidCall.order = sspConf.bids[processedBidsCount - 1].order;
       currentBidCall.reqMethod = sspConf.bids[processedBidsCount - 1].reqMethod;
-      currentBidCall.timestamp = Date.now();
       currentBidCall.nw = {
         evaluated: {
           // percieved latency


### PR DESCRIPTION
- user device detection (mobile, tablet, desktop)
- capturing network type (only for supported browsers, will not be captured for browsers that do not support this feature)
- wrapped entire onPage script in an IIFE
- keeping track of the sequence of order that bidder calls are made each auction
- keeping track of the number of ad units that are present during each auction
- keeping track of the request size (collecting the char count), for each bidder (per auction)
- keeping track of the bidder req call type (post, get, etc.) (per auction)
- bidders to keep track of during auctions are now dynamically set based on who is participating in an auction
- ensuring that the cf worker only gets called once per bidder but also keeps track of all network calls for each bid a bidder may have
- keeping track of perceived latency for each bidder bid request
- keeping track of bidder bid responses (per auction), whether or not they were used in the auction or not
- keeping track of the number of bid calls a bidder makes (per auction)
- dropped the `key` field (ex: `key: "pm"`) from each object within the bidders array
- Slimmed down the json payload size sent to the cf worker by truncating the perf resource url's to not include any query params